### PR TITLE
Make ElasticIP optional and expose PrivateIP when not allocated (#12 and #13)

### DIFF
--- a/otc/ecs.go
+++ b/otc/ecs.go
@@ -644,7 +644,7 @@ func (d *Driver) configureNetwork() error {
 
 	// Exit if ElasticIp is set to false
 	if d.ElasticIpBool == 0 { 
-		log.Debugf("%s | An ElasticIp won't be allocated", d.MachineName)
+		log.Infof("%s | An ElasticIp won't be allocated", d.MachineName)
 		return nil 
 	}
 

--- a/otc/ecs.go
+++ b/otc/ecs.go
@@ -72,6 +72,7 @@ type Driver struct {
 	JobId           string
 
 	//network
+	ElasticIpBool     int
 	ElasticIPId       string
 	ElasticIP         string
 	SecurityGroupName string
@@ -197,6 +198,12 @@ func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 			Value:  "",
 			EnvVar: "SSH_USER",
 		},
+		mcnflag.IntFlag{
+			Name: "otc-elastic-ip",
+			Usage: "Set it to 1 to allocate ElasticIP",
+			Value: 0,
+			EnvVar: "ELASTIC_IP",
+		},
 	}
 }
 
@@ -219,6 +226,7 @@ func (d *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {
 	d.BandwidthType = flags.String("otc-bandwidth-type")
 	d.ElasticIpType = flags.String("otc-elasticip-type")
 	d.SSHUser = flags.String("otc-ssh-user")
+	d.ElasticIpBool = flags.Int("otc-elastic-ip")
 	//fmt.Printf("test for region: %s\n", d.Region)
 	return d.checkConfig()
 }
@@ -633,6 +641,13 @@ func (d *Driver) checkJobStatus(jobid string) error {
 }
 
 func (d *Driver) configureNetwork() error {
+
+	// Exit if ElasticIp is set to false
+	if d.ElasticIpBool == 0 { 
+		log.Debugf("%s | An ElasticIp won't be allocated", d.MachineName)
+		return nil 
+	}
+
 	log.Debugf("%s | Allocate elastic ip ...", d.MachineName)
 
 	elasticIpCreate := &vpcModules.PublicipCreate{}


### PR DESCRIPTION
For an user who wants to create docker instances in OTC but do not provision them via ElasticIP but only via private network, we should be able to configure it in docker-machine at creation time.

Working on this feature has been requested in issues #12 and #13 (open) and in other issues already closed.

Note: I've pushed the binaries to my branch for deployment purposes