### PR TITLE
Add support for user-data

### DIFF
--- a/otcgo/ecs/instances.go
+++ b/otcgo/ecs/instances.go
@@ -31,6 +31,7 @@ type CreateInstanceAttribute struct {
 	SecGrps       []SecGrp    `json:"security_groups"`
 	AdminPass     string      `json:"adminPass"`
 	KeyName       string      `json:"key_name"`
+	UserData      []byte      `json:"user_data"`
 }
 
 type CreateInstanceArgs struct {


### PR DESCRIPTION
The OTC driver has some traces of a person attempting to support
cloud-init user data but this feature was not really available.

Add support for a new option --otc-user-data-file= which accepts
any valid cloud-init script of yaml.

This was tested against the production OTC API.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@huawei.com>